### PR TITLE
Fixes issue #9 SQL Database error

### DIFF
--- a/LocalAccountsApp/App_Data/README.md
+++ b/LocalAccountsApp/App_Data/README.md
@@ -1,0 +1,2 @@
+This folder must exist to allow SQL Server Express to create the .mdf and .ldf database files.
+This folder is listed in .gitignore so the database files do not get checked in.

--- a/LocalAccountsApp/Web.config
+++ b/LocalAccountsApp/Web.config
@@ -9,7 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-LocalAccountsApp-20141010103649.mdf;Initial Catalog=aspnet-LocalAccountsApp-20141010103649;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-LocalAccountsApp-20141010103649.mdf;Initial Catalog=aspnet-LocalAccountsApp-20141010103649;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings></appSettings>
   <system.web>


### PR DESCRIPTION
Update database connection string and ensure App_Data exists, to fix issue #9 "SQL Database error":

- Starting with Visual Studio 2013, the SQL Server Express automatic instance name is MSSQLLocalDB.
https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/sql-server-express-localdb?view=sql-server-ver15
https://docs.microsoft.com/en-us/ef/ef6/what-is-new/visual-studio

- The App_Data folder must exist to allow initial creation of the local accounts database.